### PR TITLE
This should resolve path problems using cmake only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.3)
 project(caesar_shift)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 
 set(SOURCE_FILES main.cpp)
 add_executable(caesar_shift ${SOURCE_FILES})

--- a/main.cpp
+++ b/main.cpp
@@ -1,9 +1,9 @@
 #include <iostream>
 #include <fstream>
 
-std::string PLAIN_TEXT_FILE = "./plain.txt";
-std::string CYPHER_TEXT_FILE = "./encrypted.txt";
-std::string DECYPHER_TEXT_FILE = "./decrypted.txt";
+std::string PLAIN_TEXT_FILE = "plain.txt";
+std::string CYPHER_TEXT_FILE = "encrypted.txt";
+std::string DECYPHER_TEXT_FILE = "decrypted.txt";
 int SHIFT = 1;
 
 char* encrypt(std::string plain_text, int shift);


### PR DESCRIPTION
@watkinsmi0523 with this change to the cmake list you should see the exe built in your project directory and when you run the program without arguments it should create the encrypted.txt and decryupted.txt
